### PR TITLE
More fixes for Unix build

### DIFF
--- a/esp32/modugfx.c
+++ b/esp32/modugfx.c
@@ -46,6 +46,8 @@
 #include "py/mphal.h"
 #include "py/runtime.h"
 
+#define EMU_EINK_SCREEN_DELAY_MS 500
+
 typedef struct _ugfx_obj_t { mp_obj_base_t base; } ugfx_obj_t;
 
 STATIC mp_obj_t ugfx_init(void) {
@@ -79,6 +81,9 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ugfx_clear_obj, 0, 1, ugfx_clear);
 /// Flush the display buffer to the screen
 ///
 STATIC mp_obj_t ugfx_flush() {
+#ifdef UNIX
+  mp_hal_delay_ms(EMU_EINK_SCREEN_DELAY_MS);
+#endif
   gdispFlush();
   return mp_const_none;
 }
@@ -567,6 +572,9 @@ STATIC mp_obj_t ugfx_demo(mp_obj_t hacking) {
     42 + 36,
     Black);
   gdispDrawStringBox(0, 82, 296, 40, "Anyway", robotoBlackItalic, Black, justifyCenter);
+#ifdef UNIX
+  mp_hal_delay_ms(EMU_EINK_SCREEN_DELAY_MS);
+#endif
   gdispFlush();
 
   return mp_const_none;

--- a/unix/modbadge.c
+++ b/unix/modbadge.c
@@ -112,6 +112,18 @@ STATIC mp_obj_t badge_leds_set_state_(mp_uint_t n_args, const mp_obj_t *args) {
   uint8_t *leds = (uint8_t *)mp_obj_str_get_data(args[0], &len);
   return mp_obj_new_int(badge_leds_set_state(leds));
   */
+  mp_uint_t len;
+  uint8_t *rgbw = (uint8_t *)mp_obj_str_get_data(args[0], &len);
+  printf("LEDs: ");
+  for (int i=5; i>=0; i--) {
+      uint8_t r = rgbw[i*4+0];
+      uint8_t g = rgbw[i*4+1];
+      uint8_t b = rgbw[i*4+2];
+      printf("\x1b[48;2;%u;%u;%um", r, g, b);
+      printf("\x1b[38;2;%u;%u;%um", r, g, b);
+      printf(" \x1b[0m ");
+  }
+  printf("\n");
   return mp_obj_new_int(0);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(badge_leds_set_state_obj, 1,1 ,badge_leds_set_state_);

--- a/unix/modnetwork.c
+++ b/unix/modnetwork.c
@@ -243,6 +243,8 @@ STATIC mp_obj_t esp_active(size_t n_args, const mp_obj_t *args) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_active_obj, 1, 2, esp_active);
 
 STATIC mp_obj_t esp_connect(size_t n_args, const mp_obj_t *args) {
+    mp_uint_t len;
+    printf("Pretend like we connected to %s here\n", mp_obj_str_get_data(args[1], &len));
     /*
     mp_uint_t len;
     const char *p;
@@ -267,6 +269,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(esp_connect_obj, 1, 7, esp_connect);
 
 STATIC mp_obj_t esp_disconnect(mp_obj_t self_in) {
     wifi_sta_connected = false;
+    printf("Pretend like we disconnected here\n");
     /*
      ESP_EXCEPTIONS( esp_wifi_disconnect() );
     */
@@ -344,10 +347,10 @@ STATIC mp_obj_t esp_ifconfig(size_t n_args, const mp_obj_t *args) {
 		// get
         /*dns_addr = dns_getserver(0);*/
 		mp_obj_t tuple[4] = {
-            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG),
-            netutils_format_ipv4_addr((uint8_t*) "\xff\xff\xff\x01", NETUTILS_BIG),
-            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG),
-            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG),
+            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG), // IP:      127.0.0.1
+            netutils_format_ipv4_addr((uint8_t*) "\xff\xff\xff\x01", NETUTILS_BIG), // netmask: 255.255.255.0
+            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG), // gateway: 127.0.0.1
+            netutils_format_ipv4_addr((uint8_t*) "\x7f\x00\x00\x01", NETUTILS_BIG), // dns:     127.0.0.1
 		};
 		return mp_obj_new_tuple(4, tuple);
 	} else {

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -224,6 +224,25 @@ extern const struct _mp_obj_module_t ugfx_module;
     { MP_OBJ_NEW_QSTR(MP_QSTR_network), (mp_obj_t)&mock_esp_network_module }, \
     { MP_OBJ_NEW_QSTR(MP_QSTR_badge), (mp_obj_t)&mock_badge_module }, \
 
+#define MICROPY_MODULE_WEAK_LINKS (1)
+#define MICROPY_PORT_BUILTIN_MODULE_WEAK_LINKS \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_binascii), (mp_obj_t)&mp_module_ubinascii }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_collections), (mp_obj_t)&mp_module_collections }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_errno), (mp_obj_t)&mp_module_uerrno }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_hashlib), (mp_obj_t)&mp_module_uhashlib }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_heapq), (mp_obj_t)&mp_module_uheapq }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_io), (mp_obj_t)&mp_module_io }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_json), (mp_obj_t)&mp_module_ujson }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_os), (mp_obj_t)&mp_module_os }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_random), (mp_obj_t)&mp_module_urandom }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_re), (mp_obj_t)&mp_module_ure }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_select), (mp_obj_t)&mp_module_uselect }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_socket), (mp_obj_t)&mp_module_socket }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_ssl), (mp_obj_t)&mp_module_ussl }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_struct), (mp_obj_t)&mp_module_ustruct }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_time), (mp_obj_t)&mp_module_time }, \
+    { MP_OBJ_NEW_QSTR(MP_QSTR_zlib), (mp_obj_t)&mp_module_uzlib }, \
+
 // type definitions for the specific machine
 
 // For size_t and ssize_t


### PR DESCRIPTION
I've added a few more features to the unix build of micropython.

- To simulate the slow redraw rate of the e-ink display, I've added a 500 ms delay for the Unix build of the ugfx module.
- python module names are now weakly linked to more familiar counterparts, as in the esp32 port.
- LED interface is usable for testing via rgb ansi escape codes.