### PR TITLE
UGFX input driver for micropython + SDL keyboard driver

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -166,6 +166,7 @@ SRC_C = \
 	esprtcmem.c \
 	espdeepsleep.c \
 	gdisp_lld_framebuffer.c \
+	ginput_lld_toggle.c \
 	gfx_mk.c \
 	$(SRC_MOD)
 

--- a/esp32/modugfx.c
+++ b/esp32/modugfx.c
@@ -36,8 +36,11 @@
 
 #ifndef UNIX
 #include "board_framebuffer.h"
-#include "ginput_lld_toggle_config.h"
 #endif
+#include "ginput_lld_toggle_config.h"
+
+#include <stdint.h>
+#include <badge_button.h>
 
 #include "gfx.h"
 #include "gfxconf.h"
@@ -543,6 +546,44 @@ STATIC mp_obj_t ugfx_poll(void) {
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(ugfx_poll_obj, ugfx_poll);
 
+// callback system
+
+STATIC mp_obj_t button_callbacks[BADGE_BUTTONS];
+STATIC GListener button_listeners[BADGE_BUTTONS];
+
+void ugfx_ginput_callback_handler(void *param, GEvent *pe){
+  uint8_t button = (size_t) param;
+  if(button_callbacks[button]){
+    mp_sched_schedule(button_callbacks[button], mp_obj_new_int(button));
+  }
+}
+
+/// \method ugfx_input_init()
+///
+/// Enable callbacks for button events
+///
+STATIC mp_obj_t ugfx_input_init(void) {
+  for(size_t i = 0; i < BADGE_BUTTONS; i++){
+    geventListenerInit(&button_listeners[i]);
+    button_listeners[i].callback = ugfx_ginput_callback_handler;
+    button_listeners[i].param = (void*) i;
+    geventAttachSource(&button_listeners[i], ginputGetToggle(i), GLISTEN_TOGGLE_ON|GLISTEN_TOGGLE_OFF);
+  }
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(ugfx_input_init_obj, ugfx_input_init);
+
+/// \method ugfx_input_attach(button, callback)
+///
+/// Register callbacks for button events
+///
+STATIC mp_obj_t ugfx_input_attach(mp_uint_t n_args, const mp_obj_t *args) {
+  uint8_t button = mp_obj_get_int(args[0]);
+  button_callbacks[button] = args[1];
+  return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(ugfx_input_attach_obj, 2, 2, ugfx_input_attach);
+
 // DEMO
 
 STATIC mp_obj_t ugfx_demo(mp_obj_t hacking) {
@@ -597,24 +638,22 @@ STATIC const mp_rom_map_elem_t ugfx_module_globals_table[] = {
      MP_OBJ_NEW_SMALL_INT(justifyCenter)},
     {MP_OBJ_NEW_QSTR(MP_QSTR_justifyRight), MP_OBJ_NEW_SMALL_INT(justifyRight)},
 
-    #ifndef UNIX
-      {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_UP), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_UP)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_DOWN),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_DOWN)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_LEFT),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_LEFT)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_RIGHT),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_RIGHT)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_MID), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_MID)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_A), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_A)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_B), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_B)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_SELECT),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_SELECT)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_START),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_START)},
-      {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_FLASH),
-       MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_FLASH)},
-    #endif
+    {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_UP), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_UP)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_DOWN),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_DOWN)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_LEFT),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_LEFT)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_JOY_RIGHT),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_RIGHT)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_MID), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_MID)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_A), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_A)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_B), MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_B)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_SELECT),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_SELECT)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_START),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_START)},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_BTN_FLASH),
+     MP_OBJ_NEW_SMALL_INT(BADGE_BUTTON_FLASH)},
 
 
     {MP_OBJ_NEW_QSTR(MP_QSTR_clear), (mp_obj_t)&ugfx_clear_obj},
@@ -646,6 +685,8 @@ STATIC const mp_rom_map_elem_t ugfx_module_globals_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_polygon), (mp_obj_t)&ugfx_polygon_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_fill_polygon), (mp_obj_t)&ugfx_fill_polygon_obj},
 
+    {MP_OBJ_NEW_QSTR(MP_QSTR_input_init), (mp_obj_t)&ugfx_input_init_obj},
+    {MP_OBJ_NEW_QSTR(MP_QSTR_input_attach), (mp_obj_t)&ugfx_input_attach_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_demo), (mp_obj_t)&ugfx_demo_obj},
 };
 

--- a/esp32/modugfx.c
+++ b/esp32/modugfx.c
@@ -555,7 +555,7 @@ void ugfx_ginput_callback_handler(void *param, GEvent *pe){
   size_t button = (size_t) param;
   if(button_callbacks[button] != mp_const_none){
     GEventToggle *toggle = (GEventToggle*) pe;
-    mp_sched_schedule(button_callbacks[button], mp_obj_new_bool(toggle->on));
+    mp_sched_schedule(button_callbacks[button], mp_obj_new_bool(toggle->on ? 1 : 0));
   }
 }
 

--- a/esp32/modugfx.c
+++ b/esp32/modugfx.c
@@ -552,9 +552,10 @@ STATIC mp_obj_t button_callbacks[BADGE_BUTTONS];
 STATIC GListener button_listeners[BADGE_BUTTONS];
 
 void ugfx_ginput_callback_handler(void *param, GEvent *pe){
-  uint8_t button = (size_t) param;
-  if(button_callbacks[button]){
-    mp_sched_schedule(button_callbacks[button], mp_obj_new_int(button));
+  size_t button = (size_t) param;
+  if(button_callbacks[button] != mp_const_none){
+    GEventToggle *toggle = (GEventToggle*) pe;
+    mp_sched_schedule(button_callbacks[button], mp_obj_new_bool(toggle->on));
   }
 }
 

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -159,6 +159,7 @@ SRC_C = \
 	modnetwork.c \
 	modbadge.c \
 	../../ugfx/drivers/multiple/SDL/gdisp_lld_SDL.c \
+	ginput_lld_toggle.c \
 	gfx_mk.c \
 	modos.c \
 	moduos_vfs.c \

--- a/unix/Makefile
+++ b/unix/Makefile
@@ -155,7 +155,7 @@ SRC_C = \
 	input.c \
 	file.c \
 	modmachine.c \
-	../esp32/modugfx.c \
+	modugfx.c \
 	modnetwork.c \
 	modbadge.c \
 	../../ugfx/drivers/multiple/SDL/gdisp_lld_SDL.c \

--- a/unix/gfxconf.h
+++ b/unix/gfxconf.h
@@ -231,6 +231,7 @@
 //    #define GWIN_NEED_PROGRESSBAR                    FALSE
 //        #define GWIN_PROGRESSBAR_AUTO                FALSE
 //    #define GWIN_NEED_KEYBOARD                       FALSE
+//    #define GWIN_NEED_KEYBOARD                       FALSE
 //        #define GWIN_KEYBOARD_DEFAULT_LAYOUT         VirtualKeyboard_English1
 //        #define GWIN_NEED_KEYBOARD_ENGLISH1          TRUE
 //    #define GWIN_NEED_TEXTEDIT                       FALSE
@@ -253,7 +254,7 @@
 ///////////////////////////////////////////////////////////////////////////
 // GEVENT                                                                //
 ///////////////////////////////////////////////////////////////////////////
-//#define GFX_USE_GEVENT                               FALSE
+#define GFX_USE_GEVENT                               TRUE
 
 //#define GEVENT_ASSERT_NO_RESOURCE                    FALSE
 //#define GEVENT_MAXIMUM_SIZE                          32
@@ -263,7 +264,7 @@
 ///////////////////////////////////////////////////////////////////////////
 // GTIMER                                                                //
 ///////////////////////////////////////////////////////////////////////////
-//#define GFX_USE_GTIMER                               FALSE
+#define GFX_USE_GTIMER                               TRUE
 
 //#define GTIMER_THREAD_PRIORITY                       HIGH_PRIORITY
 //#define GTIMER_THREAD_WORKAREA_SIZE                  2048
@@ -282,7 +283,7 @@
 ///////////////////////////////////////////////////////////////////////////
 // GINPUT                                                                //
 ///////////////////////////////////////////////////////////////////////////
-//#define GFX_USE_GINPUT                               FALSE
+#define GFX_USE_GINPUT                               TRUE
 
 //#define GINPUT_NEED_MOUSE                            FALSE
 //    #define GINPUT_TOUCH_STARTRAW                    FALSE
@@ -295,12 +296,12 @@
 //    #define GINPUT_TOUCH_USER_CALIBRATION_LOAD       FALSE
 //    #define GINPUT_TOUCH_USER_CALIBRATION_SAVE       FALSE
 //    #define GMOUSE_DRIVER_LIST                       GMOUSEVMT_Win32, GMOUSEVMT_Win32
-//#define GINPUT_NEED_KEYBOARD                         FALSE
+#define GINPUT_NEED_KEYBOARD                         TRUE
 //    #define GINPUT_KEYBOARD_POLL_PERIOD              200
 //    #define GKEYBOARD_DRIVER_LIST                    GKEYBOARDVMT_Win32, GKEYBOARDVMT_Win32
 //    #define GKEYBOARD_LAYOUT_OFF                     FALSE
 //        #define GKEYBOARD_LAYOUT_SCANCODE2_US        FALSE
-//#define GINPUT_NEED_TOGGLE                           FALSE
+#define GINPUT_NEED_TOGGLE                             TRUE
 //#define GINPUT_NEED_DIAL                             FALSE
 
 

--- a/unix/gfxconf.h
+++ b/unix/gfxconf.h
@@ -231,7 +231,6 @@
 //    #define GWIN_NEED_PROGRESSBAR                    FALSE
 //        #define GWIN_PROGRESSBAR_AUTO                FALSE
 //    #define GWIN_NEED_KEYBOARD                       FALSE
-//    #define GWIN_NEED_KEYBOARD                       FALSE
 //        #define GWIN_KEYBOARD_DEFAULT_LAYOUT         VirtualKeyboard_English1
 //        #define GWIN_NEED_KEYBOARD_ENGLISH1          TRUE
 //    #define GWIN_NEED_TEXTEDIT                       FALSE

--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -24,10 +24,10 @@ static uint8_t button_lookup[10] = {
                                                 GKEY_LEFT,
                                                 GKEY_RIGHT,
                                                 GKEY_ENTER,
-                                                'a',
-                                                's',
-                                                'z',
-                                                'x',
+                                                GKEY_PAGEUP,
+                                                GKEY_PAGEDOWN,
+                                                GKEY_HOME,
+                                                GKEY_END,
                                                 GKEY_DEL,
                                                };
 
@@ -55,7 +55,7 @@ ginput_lld_toggle_init(const GToggleConfig *ptc)
 {
   bits_set = 0;
   geventListenerInit(&_pl);
-  geventAttachSource(&_pl, ginputGetKeyboard(0), GLISTEN_KEYUP);
+  geventAttachSource(&_pl, ginputGetKeyboard(0), GLISTEN_KEYUP|GLISTEN_KEYREPEATSOFF);
   _pl.callback = keyboard_callback;
 }
 

--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -47,7 +47,6 @@ void keyboard_callback(void *param, GEvent *pe){
         }
       }
     }
-    printf("%02x\n", bits_set);
     ginputToggleWakeupI();
   }
 }

--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -11,7 +11,6 @@
 #if (GFX_USE_GINPUT && GINPUT_NEED_TOGGLE)
 #include "../../ugfx/src/ginput/ginput_driver_toggle.h"
 
-#include <badge_input.h>
 #include <stdio.h>
 
 #include "ginput_lld_toggle_config.h"
@@ -19,7 +18,7 @@
 GINPUT_TOGGLE_DECLARE_STRUCTURE();
 static GListener _pl;
 static uint32_t bits_set;
-static uint8_t button_lookup[BADGE_BUTTONS] = {
+static uint8_t button_lookup[10] = {
                                                 GKEY_UP,
                                                 GKEY_DOWN,
                                                 GKEY_LEFT,
@@ -38,16 +37,17 @@ void keyboard_callback(void *param, GEvent *pe){
     GEventKeyboard *ke = (GEventKeyboard *) pe;
     bits_set = 0;
     uint8_t button = ke->c[0];
-    uint8_t state = ke->c[0];
-    for(uint8_t i = 0; i < BADGE_BUTTONS; i++){
-      if(button == button_lookup[i]){
-        if(state == GKEYSTATE_KEYUP){
-          bits_set &= ~(1<<i);
-        } else {
+    uint8_t state = ke->keystate;
+    if(state & GKEYSTATE_KEYUP){
+      bits_set = 0;
+    } else {
+      for(uint8_t i = 0; i < 10; i++){
+        if(button == button_lookup[i]){
           bits_set |= (1<<i);
         }
       }
     }
+    printf("%02x\n", bits_set);
     ginputToggleWakeupI();
   }
 }

--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -35,14 +35,13 @@ static uint8_t button_lookup[10] = {
 void keyboard_callback(void *param, GEvent *pe){
   if(pe){
     GEventKeyboard *ke = (GEventKeyboard *) pe;
-    bits_set = 0;
     uint8_t button = ke->c[0];
     uint8_t state = ke->keystate;
-    if(state & GKEYSTATE_KEYUP){
-      bits_set = 0;
-    } else {
-      for(uint8_t i = 0; i < 10; i++){
-        if(button == button_lookup[i]){
+    for(uint8_t i = 0; i < 10; i++){
+      if(button == button_lookup[i]){
+        if(state & GKEYSTATE_KEYUP){
+          bits_set &= ~(1<<i);
+        } else {
           bits_set |= (1<<i);
         }
       }
@@ -54,6 +53,7 @@ void keyboard_callback(void *param, GEvent *pe){
 void
 ginput_lld_toggle_init(const GToggleConfig *ptc)
 {
+  bits_set = 0;
   geventListenerInit(&_pl);
   geventAttachSource(&_pl, ginputGetKeyboard(0), GLISTEN_KEYUP);
   _pl.callback = keyboard_callback;

--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -1,0 +1,70 @@
+/*
+ * This file is subject to the terms of the GFX License. If a copy of
+ * the license was not distributed with this file, you can obtain one at:
+ *
+ *              http://ugfx.org/license.html
+ */
+
+#include "gfx.h"
+#include "gfxconf.h"
+
+#if (GFX_USE_GINPUT && GINPUT_NEED_TOGGLE)
+#include "../../ugfx/src/ginput/ginput_driver_toggle.h"
+
+#include <badge_input.h>
+#include <stdio.h>
+
+#include "ginput_lld_toggle_config.h"
+
+GINPUT_TOGGLE_DECLARE_STRUCTURE();
+static GListener _pl;
+static uint32_t bits_set;
+static uint8_t button_lookup[BADGE_BUTTONS] = {
+                                                GKEY_UP,
+                                                GKEY_DOWN,
+                                                GKEY_LEFT,
+                                                GKEY_RIGHT,
+                                                GKEY_ENTER,
+                                                'a',
+                                                's',
+                                                'z',
+                                                'x',
+                                                GKEY_DEL,
+                                               };
+
+
+void keyboard_callback(void *param, GEvent *pe){
+  if(pe){
+    GEventKeyboard *ke = (GEventKeyboard *) pe;
+    bits_set = 0;
+    uint8_t button = ke->c[0];
+    uint8_t state = ke->c[0];
+    for(uint8_t i = 0; i < BADGE_BUTTONS; i++){
+      if(button == button_lookup[i]){
+        if(state == GKEYSTATE_KEYUP){
+          bits_set &= ~(1<<i);
+        } else {
+          bits_set |= (1<<i);
+        }
+      }
+    }
+    ginputToggleWakeupI();
+  }
+}
+
+void
+ginput_lld_toggle_init(const GToggleConfig *ptc)
+{
+  geventListenerInit(&_pl);
+  geventAttachSource(&_pl, ginputGetKeyboard(0), GLISTEN_KEYUP);
+  _pl.callback = keyboard_callback;
+}
+
+unsigned
+ginput_lld_toggle_getbits(const GToggleConfig *ptc)
+{
+    return bits_set;
+}
+
+#endif /*  GFX_USE_GINPUT && GINPUT_NEED_TOGGLE */
+

--- a/unix/ginput_lld_toggle_config.h
+++ b/unix/ginput_lld_toggle_config.h
@@ -1,9 +1,6 @@
 #ifndef GINPUT_LLD_TOGGLE_CONFIG
 #define GINPUT_LLD_TOGGLE_CONFIG
 
-// re-export BADGE_BUTTON_* constants
-#include <badge_input.h>
-
 #define GINPUT_TOGGLE_NUM_PORTS       32
 #define GINPUT_TOGGLE_CONFIG_ENTRIES   1
 

--- a/unix/ginput_lld_toggle_config.h
+++ b/unix/ginput_lld_toggle_config.h
@@ -1,0 +1,18 @@
+#ifndef GINPUT_LLD_TOGGLE_CONFIG
+#define GINPUT_LLD_TOGGLE_CONFIG
+
+// re-export BADGE_BUTTON_* constants
+#include <badge_input.h>
+
+#define GINPUT_TOGGLE_NUM_PORTS       32
+#define GINPUT_TOGGLE_CONFIG_ENTRIES   1
+
+// We are (well, will be) interrupt driven
+#define GINPUT_TOGGLE_POLL_PERIOD		TIME_INFINITE
+
+#define GINPUT_TOGGLE_DECLARE_STRUCTURE() \
+	const GToggleConfig GInputToggleConfigTable[GINPUT_TOGGLE_CONFIG_ENTRIES] = { \
+		{ 0, 0xffffffff, 0, 0 }, \
+	}
+
+#endif // GINPUT_LLD_TOGGLE_CONFIG

--- a/unix/modugfx.c
+++ b/unix/modugfx.c
@@ -1,0 +1,1 @@
+../esp32/modugfx.c

--- a/unix/mpconfigport.h
+++ b/unix/mpconfigport.h
@@ -26,6 +26,7 @@
 
 // options to control how Micro Python is built
 
+#define MICROPY_ENABLE_SCHEDULER            (1)
 #define MICROPY_ALLOC_PATH_MAX      (PATH_MAX)
 #define MICROPY_PERSISTENT_CODE_LOAD (1)
 #if !defined(MICROPY_EMIT_X64) && defined(__x86_64__)


### PR DESCRIPTION
A mechanism to register callbacks to buttons from micropython, which also works on the unix build thanks to the ugfx keyboard driver + a custom low level driver that mimicks the toggle button driver.

```
import ugfx
ugfx.init()
ugfx.input_init()

def create_callback(button):
    def callback(pressed):
        print("Button %u" % button, pressed)
    return callback

for i in range(10):
    ugfx.input_attach(i, create_callback(i))

while True:
    pass
```

This PR depends on https://github.com/SHA2017-badge/Firmware/pull/30

For the Linux/SDL version, buttons 0-9 are mapped to: up, down, left, right, enter, page up, page down, home, end, del.