### PR TITLE
Using mutex-locked version of ginputToggleWakeup

### DIFF
--- a/unix/ginput_lld_toggle.c
+++ b/unix/ginput_lld_toggle.c
@@ -46,7 +46,7 @@ void keyboard_callback(void *param, GEvent *pe){
         }
       }
     }
-    ginputToggleWakeupI();
+    ginputToggleWakeup();
   }
 }
 


### PR DESCRIPTION
Using the unlocked one made the button interrupts lag by 1 instance.