### PR TITLE
Flash firmware faster

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -15,7 +15,7 @@ FROZEN_MPY_DIR = modules
 include ../py/py.mk
 
 PORT ?= /dev/ttyUSB0
-BAUD ?= 460800
+BAUD ?= 921600
 FLASH_MODE ?= dio
 FLASH_FREQ ?= 40m
 FLASH_SIZE ?= 16MB


### PR DESCRIPTION
Nobody has time to wait, right?
All our badges should support this speed just as well. 2M and 3M speeds only for newer versions of serial IC