### PR TITLE
tell nvs_get_str() the buffer-length; lower buffer size to 256 bytes

### DIFF
--- a/esp32/modbadge.c
+++ b/esp32/modbadge.c
@@ -48,8 +48,8 @@ STATIC mp_obj_t badge_nvs_get_str_(mp_uint_t n_args, const mp_obj_t *args) {
   mp_uint_t len;
   const char *namespace = mp_obj_str_get_data(args[0], &len);
   const char *key = mp_obj_str_get_data(args[1], &len);
-  char value[1024]; // TODO wut?
-  size_t length;
+  char value[256]; // TODO wut?
+  size_t length = sizeof(value);
   esp_err_t err = badge_nvs_get_str(namespace, key, value, &length);
   if (err != ESP_OK) {
     if (n_args > 2) {


### PR DESCRIPTION
On nvs_get_str() the length should be initialized with the size of
the buffer.

Also lowered the size of the buffer. We should not store very large
strings in NVS, and we do not have that much space on the stack.
If we really need such large strings, we should use malloc or a
static buffer for reading the large string.