### PR TITLE
renamed badge_portexp to badge_fxl6408

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -662,7 +662,7 @@ BADGE_COMPONENTS_O = $(addprefix $(BADGE)/components/,\
 	badge/badge_i2c.o \
 	badge/badge_leds.o \
 	badge/badge_mpr121.o \
-	badge/badge_portexp.o \
+	badge/badge_fxl6408.o \
 	badge/badge_gpiobutton.o \
 	badge/badge_cpt112s.o \
 	badge/badge_input.o \

--- a/esp32/main.c
+++ b/esp32/main.c
@@ -52,7 +52,6 @@
 #include "modmachine.h"
 #include "mpthreadport.h"
 #include "bpp_init.h"
-#include "badge_portexp.h"
 #include "badge_pins.h"
 #include "badge_base.h"
 #include "badge_first_run.h"


### PR DESCRIPTION
(code cleanup -- part of larger PR in Firmware repos)