### PR TITLE
Up installer WiFi timeout from 4s to 15s

### DIFF
--- a/esp32/modules/installer.py
+++ b/esp32/modules/installer.py
@@ -29,7 +29,7 @@ def connectWiFi():
 
         draw_msg("Connecting to '"+ssid+"'...")
 
-        timeout = badge.nvs_get_u8('splash', 'wifi.timeout', 40)
+        timeout = 150
         while not nw.isconnected():
             time.sleep(0.1)
             timeout = timeout - 1


### PR DESCRIPTION
I've found 4 seconds is often too slow, even for enterprise WiFi networks.

I suggest we also re-evaluate if 4 seconds is the right timeout for the splash ( @Roosted7 ).