### PR TITLE
Makefile improvements

### DIFF
--- a/esp32/Makefile
+++ b/esp32/Makefile
@@ -1,3 +1,13 @@
+ifndef PROJECT_PATH
+PROJECT_PATH := $(abspath $(dir $(firstword $(MAKEFILE_LIST)))/../..)
+export PROJECT_PATH
+endif
+
+ifndef IDF_PATH
+IDF_PATH := $(PROJECT_PATH)/esp-idf
+export IDF_PATH
+endif
+
 include ../py/mkenv.mk
 
 # qstr definitions (must come before including py.mk)
@@ -23,13 +33,9 @@ FLASH_SIZE ?= 16MB
 CROSS_COMPILE ?= xtensa-esp32-elf-
 
 # paths to ESP IDF and its components
-ifeq ($(IDF_PATH),)
-$(error Please configure the ESPIDF variable)
-endif
 ESPIDF = $(IDF_PATH)
 ESPCOMP = $(ESPIDF)/components
 ESPTOOL ?= $(ESPCOMP)/esptool_py/esptool/esptool.py
-BADGE = $(IDF_PATH)/..
 
 # verify the ESP IDF version
 ESPIDF_SUPHASH := 8b274cd5a5d193a82b49aef384c303b105eda700
@@ -656,7 +662,7 @@ OBJ_ESPIDF += $(addprefix $(BUILD)/, $(ESPIDF_HEAP_O))
 # Badge magic
 
 $(BUILD)/components/%.o:
-BADGE_COMPONENTS_O = $(addprefix $(BADGE)/components/,\
+BADGE_COMPONENTS_O = $(addprefix $(PROJECT_PATH)/components/,\
 	badge/badge_base.o \
 	badge/badge_eink.o \
 	badge/badge_i2c.o \


### PR DESCRIPTION
Use a PROJECT_PATH which points to the Firmware path (it can be
overridden)
Use default IDF_PATH which points to $(PROJECT_PATH)/esp-idf.