### PR TITLE
Exposed badge_eink_display as Python function

### DIFF
--- a/esp32/modbadge.c
+++ b/esp32/modbadge.c
@@ -300,6 +300,29 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(badge_eink_png_obj, badge_eink_png);
 /* END OF PNG READER TEST */
 
 
+/* Raw frame display */
+
+STATIC mp_obj_t badge_eink_raw_frame(mp_obj_t obj_img, mp_obj_t obj_flags)
+{
+	int bufferSize = mp_obj_str_get_len(obj_img);
+	if (bufferSize != BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT)
+	{
+		nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "buffer size incorrect"));
+	}
+	
+	// convert the input buffer into a byte array
+	uint8_t* buffer = (uint8_t*)mp_obj_str_get_str(obj_img);
+	
+	int flags = mp_obj_get_int(obj_flags);
+	
+	// display the image directly
+	badge_eink_display(buffer, flags);
+
+	return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_2(badge_eink_raw_frame_obj, badge_eink_raw_frame);
+
+
 // Power (badge_power.h)
 
 STATIC mp_obj_t badge_power_init_() {
@@ -438,6 +461,7 @@ STATIC const mp_rom_map_elem_t badge_module_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_eink_busy_wait), MP_ROM_PTR(&badge_eink_busy_wait_obj)},
 
     {MP_ROM_QSTR(MP_QSTR_eink_png), MP_ROM_PTR(&badge_eink_png_obj)},
+	{MP_ROM_QSTR(MP_QSTR_eink_raw_frame), MP_ROM_PTR(&badge_eink_raw_frame_obj)},
 
 /*
     {MP_ROM_QSTR(MP_QSTR_display_picture), MP_ROM_PTR(&badge_display_picture_obj)},

--- a/esp32/modbadge.c
+++ b/esp32/modbadge.c
@@ -304,12 +304,6 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_3(badge_eink_png_obj, badge_eink_png);
 
 STATIC mp_obj_t badge_eink_raw_frame(mp_obj_t obj_img, mp_obj_t obj_flags)
 {
-	int bufferSize = mp_obj_str_get_len(obj_img);
-	if (bufferSize != BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT)
-	{
-		nlr_raise(mp_obj_new_exception_msg_varg(&mp_type_ValueError, "buffer size incorrect"));
-	}
-	
 	// convert the input buffer into a byte array
 	uint8_t* buffer = (uint8_t*)mp_obj_str_get_str(obj_img);
 	


### PR DESCRIPTION
At the moment there's no way to display a raw image from memory, which would be useful for displaying images generated outside of uGFX or downloaded from the internet. This PR aims to expose the badge_eink_display function from badge_eink.c as a Python function.

Fair warning, I don't have a way to set up a build environment for the code right now, so this is 100% untested. I've also never worked with MicroPython before. The commit might not even compile, although I did ask some folks in the sha2017-badge IRC channel to peer review it, and they found no glaring errors.

I've put a limited test application here, it should have the same functionality as demo_greyscale_img4.c in the Firmware/main/ directory, except in Python: https://pastebin.com/BWtDmGG3

Let me know if you need more info, or just want to generally condemn me for opening untested PRs!