### PR TITLE
Add time to OTA check

### DIFF
--- a/esp32/modules/tasks/otacheck.py
+++ b/esp32/modules/tasks/otacheck.py
@@ -4,7 +4,7 @@
 # License: MIT
 # Authors: Renze Nicolai <renze@rnplus.nl>
 
-import easywifi, easydraw, badge
+import easywifi, easydraw, badge, time
 
 def download_info():
     import urequests as requests


### PR DESCRIPTION
Fixes a crash when the OTA update can connect to wifi but fails to download or decode the JSON file