### PR TITLE
Use 'with open() as f:' instead of 'f = open()'

### DIFF
--- a/esp32/modules/_boot.py
+++ b/esp32/modules/_boot.py
@@ -3,7 +3,9 @@ import badge, gc, uos
 try:
     badge.mount_root()
     uos.mount(uos.VfsNative(None), '/')
-    open("/boot.py", "r")
+    with open("/boot.py", "r") as f:
+        f.close()
+
 except OSError:
     import inisetup
     vfs = inisetup.setup()

--- a/esp32/modules/launcher.py
+++ b/esp32/modules/launcher.py
@@ -59,9 +59,9 @@ def read_metadata(app):
         install_path = get_install_path()
         info_file = "%s/%s/metadata.json" % (install_path, app)
         print("Reading "+info_file+"...")
-        fd = open(info_file)
-        information = ujson.loads(fd.read())
-        return information
+        with open(info_file) as f:
+            information = f.read()
+        return ujson.loads(information)
     except BaseException as e:
         print("[ERROR] Can not read metadata for app "+app)
         sys.print_exception(e)

--- a/esp32/modules/tasks/resourcescheck.py
+++ b/esp32/modules/tasks/resourcescheck.py
@@ -18,8 +18,8 @@ def install():
 def check():
     needToInstall = True
     try:
-        fp = open("/lib/resources/version", "r")
-        version = int(fp.read(99))
+        with open("/lib/resources/version", "r") as f:
+            version = int(f.read(99))
         print("[RESOURCES] Current version: "+str(version))
         if version>=2:
             needToInstall = False

--- a/esp32/modules/tasks/services.py
+++ b/esp32/modules/tasks/services.py
@@ -34,17 +34,17 @@ def setup(drawCb=None):
         print("APP: "+app)
         try:
             #Try to open and read the json description
-            fd = open('/lib/'+app+'/service.json')
-            description = ujson.loads(fd.read())
-            fd.close()
+            with open('/lib/'+app+'/service.json') as f:
+                description = f.read()
+            description = ujson.loads(description)
         except:
             print("[SERVICES] No description found for "+app)
             continue #Or skip the app
                 
         try:
             #Try to open the service itself
-            fd = open('/lib/'+app+'/service.py')
-            fd.close()
+            with open('/lib/'+app+'/service.py') as f:
+                f.close()
         except:
             print("[SERVICES] No script found for "+app)
             continue #Or skip the app

--- a/esp32/modules/tasks/sponsorscheck.py
+++ b/esp32/modules/tasks/sponsorscheck.py
@@ -21,8 +21,8 @@ def show(force=False):
         needToInstall = True
         version = 0
         try:
-            fp = open("/lib/sponsors/version", "r")
-            version = int(fp.read(99))
+            with open("/lib/sponsors/version", "r") as f:
+                version = int(f.read(99))
             print("[SPONSORS] Current version: "+str(version))
         except:
             print("[SPONSORS] Not installed!")
@@ -31,8 +31,8 @@ def show(force=False):
         if needToInstall:
             install()
         try:
-            fp = open("/lib/sponsors/version", "r")
-            version = int(fp.read(99))
+            with open("/lib/sponsors/version", "r") as f:
+                version = int(f.read(99))
             # Now we know for sure that a version of the sponsors app has been installed
             badge.nvs_set_u8('sponsors', 'shown', 1)
             appglue.start_app("sponsors")


### PR DESCRIPTION
This automatically closes the file when leaving the code block.

(fix for 'too many open files' problem)