### PR TITLE
fix update all; update next egg if update failed.

### DIFF
--- a/esp32/modules/update.py
+++ b/esp32/modules/update.py
@@ -19,8 +19,11 @@ except OSError:
 
 for app in apps:
     easydraw.msg("Updating '"+app+"'...")
-    woezel.install(app)
-    easydraw.msg("Done!")
-    
+    try:
+        woezel.install(app)
+        easydraw.msg("Done!")
+    except:
+        print("failed update. Already newest version?")
+
 easydraw.msg("All your apps are now up-to-date!")
 stop()


### PR DESCRIPTION
Without the try-catch, the first up-to-date application/egg will stop the update-process of all other applications.