### PR TITLE
soft reboot in raw REPL mode skips boot.py (for ampy, pyboard)

### DIFF
--- a/esp32/main.c
+++ b/esp32/main.c
@@ -94,8 +94,10 @@ soft_reset:
     machine_pins_init();
 
     // run boot-up scripts
-    pyexec_frozen_module("_boot.py");
-    pyexec_file("boot.py");
+    if (pyexec_mode_kind != PYEXEC_MODE_RAW_REPL) {
+        pyexec_frozen_module("_boot.py");
+        pyexec_file("boot.py");
+    }
     // if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
     //     pyexec_file("main.py");
     // }


### PR DESCRIPTION
I needed this to use "import shell" and then use ampy or pyboard to run code, without delays or weirdness caused by the "soft reboot" triggered by these tools.

Before this change, I found ampy/pyboard would reset the board from "shell mode" into normal running mode, and there were races with power management & the WiFi OTA check which could make it fail.

After this change, the badge will stay in "shell mode" each time ampy/pyboard runs, until a hard reset or a soft reset from the "friendly" REPL.

Remaining downside, because boot.py doesn't run the hardware isn't fully initialised when ampy/pyboard runs code. `ampy ls` returns no files and `ampy put` returns ENODEV (without this change, I find `ampy ls` crashes the badge.)