### PR TITLE
Safe mode to allow recovery from malware

### DIFF
--- a/esp32/main.c
+++ b/esp32/main.c
@@ -102,7 +102,7 @@ soft_reset:
     // run boot-up scripts
     pyexec_frozen_module("_boot.py");
     if (pyexec_mode_kind != PYEXEC_MODE_RAW_REPL) {
-        pyexec_file("boot.py");
+        pyexec_frozen_module("boot.py");
     }
     // if (pyexec_mode_kind == PYEXEC_MODE_FRIENDLY_REPL) {
     //     pyexec_file("main.py");

--- a/esp32/main.c
+++ b/esp32/main.c
@@ -35,6 +35,7 @@
 #include "esp_system.h"
 #include "esp_task.h"
 #include "soc/cpu.h"
+#include "rom/rtc.h"
 
 #include "sha2017_ota.h"
 #include "esprtcmem.h"
@@ -56,6 +57,7 @@
 #include "badge_base.h"
 #include "badge_first_run.h"
 #include <badge_input.h>
+#include <badge_button.h>
 #include <badge.h>
 
 // MicroPython runs as a task under FreeRTOS
@@ -64,11 +66,15 @@
 #define MP_TASK_STACK_LEN       (MP_TASK_STACK_SIZE / sizeof(StackType_t))
 #define MP_TASK_HEAP_SIZE       (88 * 1024)
 
+//define BUTTON_SAFE_MODE ((1 << BADGE_BUTTON_A) || (1 << BADGE_BUTTON_B))
+#define BUTTON_SAFE_MODE ((1 << BADGE_BUTTON_START))
+
 STATIC StaticTask_t mp_task_tcb;
 STATIC StackType_t mp_task_stack[MP_TASK_STACK_LEN] __attribute__((aligned (8)));
 STATIC uint8_t mp_task_heap[MP_TASK_HEAP_SIZE];
 
 extern uint32_t reset_cause;
+extern bool in_safe_mode;
 
 void mp_task(void *pvParameter) {
     volatile uint32_t sp = (uint32_t)get_sp();
@@ -176,6 +182,13 @@ void app_main(void) {
 		}
 
 	} else {
+		uint32_t reset_cause = rtc_get_reset_reason(0);
+		if (reset_cause != DEEPSLEEP_RESET) {
+			badge_init();
+			if ((badge_input_button_state & BUTTON_SAFE_MODE) == BUTTON_SAFE_MODE) {
+				in_safe_mode = true;
+			}
+		}
 		xTaskCreateStaticPinnedToCore(mp_task, "mp_task", MP_TASK_STACK_LEN, NULL, MP_TASK_PRIORITY,
 				&mp_task_stack[0], &mp_task_tcb, 0);
 	}

--- a/esp32/modbadge.c
+++ b/esp32/modbadge.c
@@ -242,7 +242,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(badge_mpr121_get_touch_info_obj, badge_mpr121_g
 #endif // I2C_MPR121_ADDR
 
 
-bool in_safe_mode = false;
+bool RTC_DATA_ATTR in_safe_mode = false;
 STATIC mp_obj_t badge_safe_mode() {
   return mp_obj_new_bool(in_safe_mode);
 }

--- a/esp32/modbadge.c
+++ b/esp32/modbadge.c
@@ -242,6 +242,11 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_0(badge_mpr121_get_touch_info_obj, badge_mpr121_g
 #endif // I2C_MPR121_ADDR
 
 
+bool in_safe_mode = false;
+STATIC mp_obj_t badge_safe_mode() {
+  return mp_obj_new_bool(in_safe_mode);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(badge_safe_mode_obj, badge_safe_mode);
 // E-Ink (badge_eink.h)
 
 STATIC mp_obj_t badge_eink_init_() {
@@ -681,6 +686,8 @@ STATIC const mp_rom_map_elem_t badge_module_globals_table[] = {
     {MP_OBJ_NEW_QSTR(MP_QSTR_mount_sdcard), (mp_obj_t)&badge_mount_sdcard_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_unmount_sdcard), (mp_obj_t)&badge_unmount_sdcard_obj},
     {MP_OBJ_NEW_QSTR(MP_QSTR_mount_bpp), (mp_obj_t)&badge_mount_bpp_obj},
+
+    {MP_OBJ_NEW_QSTR(MP_QSTR_safe_mode), (mp_obj_t)&badge_safe_mode_obj},
 
 };
 

--- a/esp32/modules/_boot.py
+++ b/esp32/modules/_boot.py
@@ -1,13 +1,6 @@
 import badge, gc, uos
 
-try:
-    badge.mount_root()
-    uos.mount(uos.VfsNative(None), '/')
-    with open("/boot.py", "r") as f:
-        f.close()
-
-except OSError:
-    import inisetup
-    vfs = inisetup.setup()
+badge.mount_root()
+uos.mount(uos.VfsNative(None), '/')
 
 gc.collect()

--- a/esp32/modules/boot.py
+++ b/esp32/modules/boot.py
@@ -1,16 +1,13 @@
-import uos
-
-def boot():
-    print("Updating 'boot.py'...")
-    with open("/boot.py", "w") as f:
-            f.write("""\
 # This file is executed on every boot (including wake-boot from deepsleep)
 import badge, machine, esp, ugfx, sys
 badge.init()
 ugfx.init()
 esp.rtcmem_write(0,0)
 esp.rtcmem_write(1,0)
-splash = badge.nvs_get_str('boot','splash','splash')
+if badge.safe_mode():
+    splash = 'splash'
+else:
+    splash = badge.nvs_get_str('boot','splash','splash')
 if machine.reset_cause() != machine.DEEPSLEEP_RESET:
     print('[BOOT] Cold boot')
 else:
@@ -39,4 +36,3 @@ except BaseException as e:
     time.sleep(5)
     import appglue
     appglue.home()
-    """)

--- a/esp32/modules/inisetup.py
+++ b/esp32/modules/inisetup.py
@@ -1,8 +1,0 @@
-import uos
-
-def setup():
-    print("Performing initial setup")
-    vfs = uos.VfsNative(True)
-    import create
-    create.boot()
-    return vfs

--- a/esp32/modules/launcher.py
+++ b/esp32/modules/launcher.py
@@ -166,9 +166,16 @@ def start():
     ugfx.clear(ugfx.WHITE)
     ugfx.flush()
 
-    ugfx.string_box(148,0,148,26, "STILL", "Roboto_BlackItalic24", ugfx.BLACK, ugfx.justifyCenter)
+    if badge.safe_mode():
+	still = "SAFE"
+	anyway = "Mode"
+    else:
+	still = "STILL"
+	anyway = "Anyway"
+
+    ugfx.string_box(148,0,148,26, still, "Roboto_BlackItalic24", ugfx.BLACK, ugfx.justifyCenter)
     ugfx.string_box(148,23,148,23, "Hacking", "PermanentMarker22", ugfx.BLACK, ugfx.justifyCenter)
-    ugfx.string_box(148,48,148,26, "Anyway", "Roboto_BlackItalic24", ugfx.BLACK, ugfx.justifyCenter)
+    ugfx.string_box(148,48,148,26, anyway, "Roboto_BlackItalic24", ugfx.BLACK, ugfx.justifyCenter)
 
     #the line under the text
     str_len = ugfx.get_string_width("Hacking","PermanentMarker22")

--- a/esp32/modules/post_ota.py
+++ b/esp32/modules/post_ota.py
@@ -1,8 +1,6 @@
 import badge, easydraw
 
 def u0to1():
-    import create
-    create.boot()
     easydraw.msg("Applied patch 1")
 
 def u1to2():

--- a/esp32/modules/splash.py
+++ b/esp32/modules/splash.py
@@ -35,10 +35,18 @@ def draw(mode, goingToSleep=False):
                 info2 = 'Press select to start OTA update'
             else:
                 info2 = ''
-        l = ugfx.get_string_width(info1,"Roboto_Regular12")
-        ugfx.string(296-l, 0, info1, "Roboto_Regular12",ugfx.BLACK)
-        l = ugfx.get_string_width(info2,"Roboto_Regular12")
-        ugfx.string(296-l, 12, info2, "Roboto_Regular12",ugfx.BLACK)
+
+	def disp_string_right(y, s):
+	    l = ugfx.get_string_width(s,"Roboto_Regular12")
+	    ugfx.string(296-l, y, s, "Roboto_Regular12",ugfx.BLACK)
+
+	disp_string_right(0, info1)
+	disp_string_right(12, info2)
+
+	if badge.safe_mode():
+	    disp_string_right(92, "Safe Mode - services disabled")
+	    disp_string_right(104, "Sleep disabled - will drain battery quickly")
+	    disp_string_right(116, "Press Reset button to exit")
         
         easydraw.nickname()
         
@@ -156,7 +164,8 @@ if not easywifi.failure():
 if not easywifi.failure():
     spoc.show(False)    # Check sponsors
 
-services.setup(draw) # Start services
+if not badge.safe_mode():
+    services.setup(draw) # Start services
 
 draw(False)
 services.force_draw()

--- a/esp32/modules/tasks/powermanagement.py
+++ b/esp32/modules/tasks/powermanagement.py
@@ -18,7 +18,7 @@ def pm_task():
     idleTime = virtualtimers.idle_time()
     print("[Power management] Next task wants to run in "+str(idleTime)+" ms.")
         
-    if idleTime>30000:
+    if idleTime>30000 and not badge.safe_mode():
         global onSleepCallback
         if not onSleepCallback==None:
             print("[Power management] Running onSleepCallback...")

--- a/esp32/modules/version.py
+++ b/esp32/modules/version.py
@@ -1,2 +1,2 @@
-build = 8
-name = "Maffe Maniak"
+build = 9
+name = "Sinistere Site"

--- a/esp32/mpconfigport.h
+++ b/esp32/mpconfigport.h
@@ -159,8 +159,7 @@
 #define MICROPY_SDMMC_USE_DRIVER            (1)
 #define MICROPY_SDMMC_SHOW_INFO             (1)
 
-// use vfs's functions for import stat and builtin open
-#define mp_import_stat mp_vfs_import_stat
+// use vfs's functions for builtin open
 #define mp_builtin_open mp_vfs_open
 #define mp_builtin_open_obj mp_vfs_open_obj
 


### PR DESCRIPTION
Move boot.py out of the filesystem and into the firmware. Implement safe mode to force the default splash, disable services and prevent sleeping. This should allow the removal of any malicious code from the filesystem without needing a USB connection to a computer.

Hold the Start button during cold boot to enter safe mode.