### PR TITLE
Introduce ugfx_screen_flipped in the emulator, too

### DIFF
--- a/unix/modbadge.c
+++ b/unix/modbadge.c
@@ -235,3 +235,5 @@ const mp_obj_module_t mock_badge_module = {
     .base = {&mp_type_module},
     .globals = (mp_obj_dict_t *)&mock_badge_module_globals,
 };
+
+bool ugfx_screen_flipped = false;


### PR DESCRIPTION
It's on the firmware in ./components/ugfx-glue/board_framebuffer.h
since 301c8bd88c99154cbf27e3e08a5dcd8536a32d02