### PR TITLE
Stop the badge waking up every few tens of seconds

### DIFF
--- a/esp32/modules/tasks/badgeeventreminder.py
+++ b/esp32/modules/tasks/badgeeventreminder.py
@@ -12,12 +12,12 @@ whenToTrigger = 1502191800 - 600
 def ber_task():
     global whenToTrigger
     now = time.time()
-    if now>=whenToTrigger:
+    if now >= whenToTrigger and now < whenToTrigger + 600 + 3600:
         badge.nvs_set_u8('badge','evrt',1)
         print("BADGE EVENT REMINDER ACTIVATED")
         appglue.start_app("badge_event_reminder")
     idleFor = whenToTrigger - now
-    if idleFor<0:
+    if idleFor < 0:
         idleFor = 0
     return idleFor * 1000
 

--- a/esp32/modules/tasks/badgeeventreminder.py
+++ b/esp32/modules/tasks/badgeeventreminder.py
@@ -19,7 +19,7 @@ def ber_task():
     idleFor = whenToTrigger - now
     if idleFor<0:
         idleFor = 0
-    return idleFor
+    return idleFor * 1000
 
 def enable():
     if badge.nvs_get_u8('badge','evrt',0)==0:


### PR DESCRIPTION
Return the number of ms, not seconds, from the badge_event_reminder task. Prevents the badge waking up increasingly often as the event approaches.