### PR TITLE
Cope better with long package names

### DIFF
--- a/esp32/modules/installer.py
+++ b/esp32/modules/installer.py
@@ -48,12 +48,9 @@ def show_description(active):
 def move_sel(active,dir_):
 	if active:
 		sel = options.selected_index()
-		print("Ingoing:", sel)
 		while sel > 0 and sel < len(packages) and packages[sel] is None:
-			print("Dummy:", sel, packages[sel])
 			sel += dir_
 		if sel > 0 and sel < len(packages):
-			print("Final:", sel)
 			options.selected_index(sel)
 		show_description(True)
 
@@ -121,9 +118,6 @@ def list_apps(slug):
 					if count:
 						i += 1
 						packages.insert(i, None)
-						print("Extra:", i, s)
-					else:
-						print("First:", i, s)
 					count += 1
 					if count == 3: # Cut off the rest
 						s = ""
@@ -135,7 +129,6 @@ def list_apps(slug):
 				if count: # Should be unneeded, defensive
 					i += 1
 					packages.insert(i, None)
-					print("Extra:", i, s)
 		i += 1
 	options.selected_index(0)
 


### PR DESCRIPTION
This fixes a large part of the issue SHA2017-badge/Firmware#192 : it spreads long app titles over multiple lines. When the cursor moves, it moves several lines at once for these long names.

Remaining bugs:
- If moving to a package below a long package, and the package moved to is partly out of view, the list does not scroll to get it fully in view.
- Even though it appears that ugfx computes ugfx.get_string_width() the same way (hunting down a few function calls in the C code), adding the widths of ugfx.get_char_width() together still sometimes produces overly long strings, for instance for this package:
    ;;)''2303211-2194523023klfrsdkfdlk;df;;''''{}{}{[[]]]]])))(()_)}}./.,////\\\\
  (No, that wasn't my cat on the keyboard, that's the name of the package! It's in "uncategorised".)

I don't readily know how to fix these bugs, which explains them still being there.

Also, the list of installed apps in the launcher suffers from the same issue, I noticed belatedly. So perhaps the better fix is in the C code.