### PR TITLE
Add/fixup timezone support

### DIFF
--- a/esp32/modules/boot.py
+++ b/esp32/modules/boot.py
@@ -1,9 +1,15 @@
 # This file is executed on every boot (including wake-boot from deepsleep)
-import badge, machine, esp, ugfx, sys
+import badge, machine, esp, ugfx, sys, time
 badge.init()
 ugfx.init()
+
 esp.rtcmem_write(0,0)
 esp.rtcmem_write(1,0)
+
+# setup timezone
+timezone = badge.nvs_get_str('system', 'timezone', 'CET-1CEST-2,M3.5.0/02:00:00,M10.5.0/03:00:00')
+time.settimezone(timezone)
+
 if badge.safe_mode():
     splash = 'splash'
 else:

--- a/esp32/modules/ntp.py
+++ b/esp32/modules/ntp.py
@@ -1,7 +1,6 @@
 ### Description: Update the badge's time via NTP
 ### License: MIT
 
-import database
 import socket
 
 NTP_DELTA = 2208988800
@@ -42,14 +41,6 @@ def set_NTP_time():
 	if t is None:
 		print("Could not set time from NTP")
 		return False
-
-	tz = 0
-	with database.Database() as db:
-		tz = db.get("timezone", 200) # default to CEST
-
-	tz_minutes = int(abs(tz) % 100) * (1 if tz >= 0 else -1)
-	tz_hours = int(tz / 100)
-	t += (tz_hours * 3600) + (tz_minutes * 60)
 
 	tm = time.localtime(t)
 	tm = tm[0:3] + (0,) + tm[3:6] + (0,)


### PR DESCRIPTION
In C wrappers:

- stop using timeutils.h
- use localtime() instead of gmtime()
- set daylight savings time to unknown when calling mktime()
- add settimezone() method to time module

In micropython scripts:

- set timezone on boot (retrieve it from nvs)
- remove timezone code from ntp client
