### PR TITLE
Cut off strings too long to show in ugfx.List

### DIFF
--- a/esp32/ugfx_widgets.c
+++ b/esp32/ugfx_widgets.c
@@ -635,7 +635,13 @@ void BWgwinListDefaultDraw(GWidgetObject* gw, void* param) {
 				}
 			}
 		#endif
-		gdispGFillStringBox(gw->g.display, gw->g.x+x+LST_HORIZ_PAD, gw->g.y+y, iwidth-LST_HORIZ_PAD, iheight, qi2li->text, gw->g.font, text, fill, justifyLeft);
+		#if GDISP_NEED_CLIP
+			gdispGSetClip(gw->g.display, gw->g.x+x+LST_HORIZ_PAD, gw->g.y+y, iwidth-LST_HORIZ_PAD, MIN(iheight, gw->g.height-y-1));
+		#endif
+		gdispGFillString(gw->g.display, gw->g.x+x+LST_HORIZ_PAD, gw->g.y+y, qi2li->text, gw->g.font, text, fill);
+		#if GDISP_NEED_CLIP
+			gdispGSetClip(gw->g.display, gw->g.x+1, gw->g.y+1, gw->g.width-2, gw->g.height-2);
+		#endif
 	}
 
 	// Fill any remaining item space


### PR DESCRIPTION
This relates to pull request #216. @basvs wrote:

> I guess we need to disable the 'center vertically' in C code.

This patch does exactly that. Since this patch is already very useful on its own, I created a new pull request for it.

I'm not too sure about the #ifdef GDISP_NEED_CLIP, though it will compile without it defined, it will render very wrongly. Maybe compilation should fail, perhaps with an error pragma?