### PR TITLE
Run applications from bpp and sdcard as well.

### DIFF
--- a/esp32/main.c
+++ b/esp32/main.c
@@ -88,7 +88,9 @@ mp_import_stat_t
 mp_import_stat(const char *path) {
 	if (in_safe_mode) {
 		// be more strict in which modules we would like to load
-		if (strncmp(path, "/lib/", 5) != 0) {
+		if (strncmp(path, "/lib/", 5) != 0
+				&& strncmp(path, "/bpp/lib/", 9) != 0
+				&& strncmp(path, "/sdcard/lib/", 12) != 0) {
 			return MP_IMPORT_STAT_NO_EXIST;
 		}
 
@@ -129,8 +131,11 @@ soft_reset:
     gc_init(mp_task_heap, mp_task_heap + sizeof(mp_task_heap));
     mp_init();
     mp_obj_list_init(mp_sys_path, 0);
+    // library-path '' is needed for the internal modules.
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR_));
     mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_lib));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_bpp_slash_lib));
+    mp_obj_list_append(mp_sys_path, MP_OBJ_NEW_QSTR(MP_QSTR__slash_sdcard_slash_lib));
     mp_obj_list_init(mp_sys_argv, 0);
     readline_init0();
 

--- a/esp32/modules/boot.py
+++ b/esp32/modules/boot.py
@@ -27,6 +27,12 @@ else:
 
 try:
     if not splash=="shell":
+        if splash.startswith('bpp '):
+            splash = splash[4:len(splash)]
+            badge.mount_bpp()
+        elif splash.startswith('sdcard '):
+            splash = splash[7:len(splash)]
+            badge.mount_sdcard()
         __import__(splash)
     else:
         ugfx.clear(ugfx.WHITE)

--- a/esp32/qstrdefsport.h
+++ b/esp32/qstrdefsport.h
@@ -28,3 +28,5 @@
 
 // Entries for sys.path
 Q(/lib)
+Q(/bpp/lib)
+Q(/sdcard/lib)


### PR DESCRIPTION
- Add /bpp/lib and /sdcard/lib to sys.path
- Add 'bpp ' and 'sdcard ' prefix to mount bpp or sdcard on boot.