### PR TITLE
Move badge.eink_busy_wait() to deepsleep module.

### DIFF
--- a/esp32/modules/appglue.py
+++ b/esp32/modules/appglue.py
@@ -10,7 +10,6 @@ def start_app(app, display = True):
             ugfx.string(0,  25, "Returning to homescreen...","Roboto_Regular12",ugfx.BLACK)
         ugfx.flush(ugfx.LUT_FASTER)
     esp.rtcmem_write_string(app)
-    badge.eink_busy_wait()
     deepsleep.reboot()
 
 def home():

--- a/esp32/modules/deepsleep.py
+++ b/esp32/modules/deepsleep.py
@@ -1,11 +1,13 @@
-import machine
+import machine, badge
 
 pin = machine.Pin(25)
 rtc = machine.RTC()
 rtc.wake_on_ext0(pin = pin, level = 0)
 
 def start_sleeping(time=0):
+    badge.eink_busy_wait()
     machine.deepsleep(time)
 
 def reboot():
+    badge.eink_busy_wait()
     machine.deepsleep(1)

--- a/esp32/modules/setup.py
+++ b/esp32/modules/setup.py
@@ -22,7 +22,6 @@ def asked_nickname(value):
         badge.nvs_set_u8('badge', 'setup.state', 2) # Skip the sponsors
         badge.nvs_set_u8('sponsors', 'shown', 1)
 
-    badge.eink_busy_wait()
     appglue.home()
 
 ugfx.init()

--- a/esp32/modules/splash.py
+++ b/esp32/modules/splash.py
@@ -21,7 +21,6 @@ def draw(mode, goingToSleep=False):
     if mode:
         # We flush the buffer and wait
         ugfx.flush(ugfx.LUT_FULL)
-        badge.eink_busy_wait()
     else:
         # We prepare the screen refresh
         ugfx.clear(ugfx.WHITE)

--- a/esp32/modules/tasks/services.py
+++ b/esp32/modules/tasks/services.py
@@ -159,8 +159,6 @@ def draw_task():
         print("[DEBUG] Deleted draw callback: ",dcb)
         drawCallbacks = list(dcb for dcb in drawCallbacks if dcb!=deleted[i])
     
-    badge.eink_busy_wait()
-    
     if requestedInterval<1000:
         #Draw at most once a second
         print("[SERVICES] Can't draw more than once a second!")


### PR DESCRIPTION
You normally never have to call the badge.eink_busy_wait().
(but do call the method right before going to sleep or going
 into reboot)